### PR TITLE
DBR 11 compatibility fixes

### DIFF
--- a/src/benvy/databricks/repos/project_root_resolver.py
+++ b/src/benvy/databricks/repos/project_root_resolver.py
@@ -12,9 +12,7 @@ def resolve_project_root() -> str:
 
 
 def resolve_repository_root() -> str:
-    # Databricks automatically adds repository root dir and current notebook dir to sys path
-    # and also sets current working directory to this current notebook dir, e.g.
-    # syspath = ["/Workspace/Repos/folder/repository", "/Workspace/Repos/folder/repository/src/dir", ...]
-    # cwd = "/Workspace/Repos/folder/repository/src/dir"
-    # So we take the shortest path that that is contained in current working directory
-    return min([path for path in sys.path if path in os.getcwd()], key=len)
+    # Databricks automatically adds repository root dir and current notebook dir to sys path, e.g.
+    # ["/Workspace/Repos/folder/repository", "/Workspace/Repos/folder/repository/src/dir", ...]
+    # So we take the shortest path that starts with '/Workspace/Repos'
+    return min([path for path in sys.path if path.startswith("/Workspace/Repos")], key=len)


### PR DESCRIPTION
For some reason on DBR11+ there is an empty string in sys.path which breaks repository root resolvement. So we will stick with detecting repository path by checking it starts with '/Workspace/Repos'